### PR TITLE
Added multi-get for albums

### DIFF
--- a/spotify.js
+++ b/spotify.js
@@ -42,6 +42,13 @@ function getSpotifyPlayer() {
         });
     }
 
+    function fetchSpotifyAlbums(sids, callback) {
+        var url = 'https://api.spotify.com/v1/albums?ids=' + sids.join(',');
+        $.getJSON(url, function(albums) {
+            callback(albums.albums);
+        });
+    }
+
     function showSpotifyAlbum(album) {
         $("#rp-album-art").attr('src', album.images.MEDIUM.image_url);
     }
@@ -128,10 +135,16 @@ function getSpotifyPlayer() {
             if (tracks.length != songs.length) {
                 console.log("Mismatch of songs and tracks", songs, tracks);
             }
+
+            // get album info
+            var albumIds = [];
             _.each(tracks, function(track, i) {
-                songs[i].spotifyTrack = track;
-                fetchSpotifyAlbum(track.album.id, function(album) {
-                    track.fullAlbum = album;
+                albumIds.push(track.album.id);
+            });
+            fetchSpotifyAlbums(albumIds, function(albums) {
+                _.each(tracks, function(track, i) {
+                    track.fullAlbum = albums[i];
+                    songs[i].spotifyTrack = track;
                     callback(songs[i]);
                 });
             });


### PR DESCRIPTION
Using the albums?ids=... endpoint we can get information for multiple albums, batching multiple requests into a single one.
