### PR TITLE
Fixed album image reference and avoid extra request

### DIFF
--- a/index.html
+++ b/index.html
@@ -204,7 +204,7 @@ function songChanged(song) {
 
 function getPlayer(song) {
     var playerInfo = {
-        bigIcon:song.spotifyTrack.fullAlbum.images.MEDIUM.image_url,
+        bigIcon:song.spotifyTrack.album.images.medium.url,
         name:song.spotifyTrack.name,
         artist:song.spotifyTrack.artists[0].name
     };

--- a/spotify.js
+++ b/spotify.js
@@ -35,20 +35,6 @@ function getSpotifyPlayer() {
         });
     }
 
-    function fetchSpotifyAlbum(sid, callback) {
-        var url = 'https://api.spotify.com/v1/albums/' + sid;
-        $.getJSON(url, function(album) {
-            callback(album);
-        });
-    }
-
-    function fetchSpotifyAlbums(sids, callback) {
-        var url = 'https://api.spotify.com/v1/albums?ids=' + sids.join(',');
-        $.getJSON(url, function(albums) {
-            callback(albums.albums);
-        });
-    }
-
     function showSpotifyAlbum(album) {
         $("#rp-album-art").attr('src', album.images.MEDIUM.image_url);
     }
@@ -135,18 +121,9 @@ function getSpotifyPlayer() {
             if (tracks.length != songs.length) {
                 console.log("Mismatch of songs and tracks", songs, tracks);
             }
-
-            // get album info
-            var albumIds = [];
             _.each(tracks, function(track, i) {
-                albumIds.push(track.album.id);
-            });
-            fetchSpotifyAlbums(albumIds, function(albums) {
-                _.each(tracks, function(track, i) {
-                    track.fullAlbum = albums[i];
-                    songs[i].spotifyTrack = track;
-                    callback(songs[i]);
-                });
+                songs[i].spotifyTrack = track;
+                callback(songs[i]);
             });
         });
     }


### PR DESCRIPTION
The property for the image available sizes has been renamed, and the image is now returned for a track lookup through its `album` property.
